### PR TITLE
Migrate from RssParser 5 to RssParser 6

### DIFF
--- a/app/src/main/kotlin/com/mr3y/ludi/core/network/rssparser/internal/DefaultParser.kt
+++ b/app/src/main/kotlin/com/mr3y/ludi/core/network/rssparser/internal/DefaultParser.kt
@@ -8,12 +8,13 @@ import com.mr3y.ludi.core.model.Source
 import com.mr3y.ludi.core.model.Title
 import com.mr3y.ludi.core.network.model.toZonedDateTime
 import com.mr3y.ludi.core.network.rssparser.Parser
-import com.prof.rssparser.Article
+import com.prof18.rssparser.model.RssItem
+import com.prof18.rssparser.RssParser
 import me.tatarka.inject.annotations.Inject
 
 @Inject
 internal class DefaultParser(
-    private val parser: com.prof.rssparser.Parser
+    private val parser: RssParser
 ) : Parser {
     override suspend fun parseNewsArticlesAtUrl(url: String, source: Source): List<NewsArticle?> {
         return fetchArticlesAt(url).map { it.toNewsArticle(source) }
@@ -27,9 +28,9 @@ internal class DefaultParser(
         return fetchArticlesAt(url).map { it.toNewReleaseArticle(source) }
     }
 
-    private suspend inline fun fetchArticlesAt(url: String) = parser.getChannel(url).articles
+    private suspend inline fun fetchArticlesAt(url: String) = parser.getRssChannel(url).items
 
-    private fun Article.toNewsArticle(source: Source): NewsArticle? {
+    private fun RssItem.toNewsArticle(source: Source): NewsArticle? {
         return NewsArticle(
             title = Title.Plain(title ?: return null),
             description = description?.let { MarkupText(it) },
@@ -42,7 +43,7 @@ internal class DefaultParser(
         )
     }
 
-    private fun Article.toNewReleaseArticle(source: Source): NewReleaseArticle? {
+    private fun RssItem.toNewReleaseArticle(source: Source): NewReleaseArticle? {
         return NewReleaseArticle(
             title = Title.Plain(title ?: return null),
             description = description?.let { MarkupText(it) },
@@ -52,7 +53,7 @@ internal class DefaultParser(
         )
     }
 
-    private fun Article.toReviewArticle(source: Source): ReviewArticle? {
+    private fun RssItem.toReviewArticle(source: Source): ReviewArticle? {
         return ReviewArticle(
             title = Title.Plain(title ?: return null),
             description = description?.let { MarkupText(it) },

--- a/app/src/main/kotlin/com/mr3y/ludi/di/NetworkComponent.kt
+++ b/app/src/main/kotlin/com/mr3y/ludi/di/NetworkComponent.kt
@@ -1,10 +1,10 @@
 package com.mr3y.ludi.di
 
-import android.content.Context
 import com.mr3y.ludi.BuildConfig
+import com.mr3y.ludi.core.network.rssparser.Parser
 import com.mr3y.ludi.core.network.rssparser.internal.DefaultParser
 import com.mr3y.ludi.di.annotations.Singleton
-import com.prof.rssparser.Parser
+import com.prof18.rssparser.RssParser
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.api.createClientPlugin
@@ -17,16 +17,13 @@ interface NetworkComponent {
 
     @Singleton
     @Provides
-    fun provideThirdPartyRssParserInstance(applicationContext: Context): Parser {
-        return Parser.Builder()
-            .context(applicationContext)
-            .cacheExpirationMillis(8L * 60L * 60L * 1000L)
-            .build()
+    fun provideThirdPartyRssParserInstance(): RssParser {
+        return RssParser()
     }
 
     @Singleton
     @Provides
-    fun provideInternalRssParserInstance(parser: Parser): com.mr3y.ludi.core.network.rssparser.Parser {
+    fun provideInternalRssParserInstance(parser: RssParser): Parser {
         return DefaultParser(parser)
     }
 

--- a/versions.properties
+++ b/versions.properties
@@ -30,22 +30,7 @@ version.com.google.protobuf..protoc=3.22.4
 
 version.com.google.testparameterinjector..test-parameter-injector=1.12
 
-version.com.prof18.rssparser..rssparser=5.0.3
-##                          # available=6.0.0-dev01
-##                          # available=6.0.0-dev02
-##                          # available=6.0.0-dev03
-##                          # available=6.0.0-dev05
-##                          # available=6.0.0-dev06
-##                          # available=6.0.0-dev07
-##                          # available=6.0.0-alpha01
-##                          # available=6.0.0-alpha02
-##                          # available=6.0.0-alpha03
-##                          # available=6.0.0-alpha04
-##                          # available=6.0.0-alpha05
-##                          # available=6.0.0-alpha06
-##                          # available=6.0.0-alpha07
-##                          # available=6.0.0
-##                          # available=6.0.1
+version.com.prof18.rssparser..rssparser=6.0.3
 
 version.firebase-analytics-ktx=21.3.0
 
@@ -86,12 +71,6 @@ version.google.dagger=2.48
 version.google.accompanist=0.32.0
 ##             # available=0.33.0-alpha
 ##             # available=0.33.1-alpha
-
-## unused
-version.com.prof18.rssparser.rssparser=5.0.3
-##                         # available=6.0.0-dev01
-##                         # available=6.0.0-dev02
-##                         # available=6.0.0-dev03
 
 ## unused
 version.com.pinterest.ktlint=0.47.1


### PR DESCRIPTION
This brings multiplatform parsing capabilities, but also as a side effect Caching parsed feeds is no longer supported and we have to do that ourselves.